### PR TITLE
chore: align dependency pins between pyproject and requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "django>=5.1.14",
-    "django-widget-tweaks>=1.5.0",
-    "python-dotenv>=1.1.0",
-    "ruff>=0.11.10",
+    "django==5.1.14",
+    "django-widget-tweaks==1.5.0",
+    "python-dotenv==1.1.0",
+    "ruff==0.11.10",
 ]
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Update `pyrproject.toml` so that requirements are explicitly pinned to specific versions (which matches `requirements.txt` which already does this). 